### PR TITLE
Auto installation of hscollider.

### DIFF
--- a/tools/hscollider/CMakeLists.txt
+++ b/tools/hscollider/CMakeLists.txt
@@ -108,3 +108,5 @@ add_custom_target(
         -Z0
     DEPENDS hscollider
 )
+
+install(TARGETS hscollider DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Now after `make install` hscollider should be written to /usr/local/bin by default.